### PR TITLE
Fix ARABIC LETTER HIGH HAMZA (U+0674)

### DIFF
--- a/sources/NotoKufiArabic.glyphs
+++ b/sources/NotoKufiArabic.glyphs
@@ -721,83 +721,51 @@ unicode = 0621;
 },
 {
 glyphname = "highhamza-ar";
-lastChange = "2021-05-25 11:56:32 +0000";
+lastChange = "2022-07-06 15:38:00 +0000";
 layers = (
 {
-anchors = (
-{
-name = bottom;
-position = "{0, 706}";
-},
-{
-name = top;
-position = "{0, 928}";
-}
-);
 components = (
 {
-name = "hamzaabove-ar";
+alignment = -1;
+name = "hamza-ar";
+transform = "{1, 0, 0, 1, 0, 250}";
 }
 );
 layerId = "410295A1-92BC-4707-ABFC-13885E60878B";
-width = 0;
+width = 454;
 },
 {
-anchors = (
-{
-name = bottom;
-position = "{0, 697}";
-},
-{
-name = top;
-position = "{2, 955}";
-}
-);
 components = (
 {
-name = "hamzaabove-ar";
+alignment = -1;
+name = "hamza-ar";
+transform = "{1, 0, 0, 1, 0, 250}";
 }
 );
 layerId = "15908E2C-AB74-4DC1-B0E7-8741EE8F4DA5";
-width = 0;
+width = 490;
 },
 {
-anchors = (
-{
-name = bottom;
-position = "{0, 727}";
-},
-{
-name = top;
-position = "{2, 985}";
-}
-);
 components = (
 {
-name = "hamzaabove-ar";
+alignment = -1;
+name = "hamza-ar";
+transform = "{1, 0, 0, 1, 0, 220}";
 }
 );
 layerId = "307C4A58-79B8-4138-817C-FBEE21722E1A";
-width = 0;
+width = 526;
 },
 {
-anchors = (
-{
-name = bottom;
-position = "{0, 699}";
-},
-{
-name = top;
-position = "{2, 1007}";
-}
-);
 components = (
 {
-name = "hamzaabove-ar";
+alignment = -1;
+name = "hamza-ar";
+transform = "{1, 0, 0, 1, 0, 200}";
 }
 );
 layerId = "DCD2D043-4E01-4B5D-9248-443A06E88532";
-width = 0;
+width = 550;
 }
 );
 unicode = 0674;
@@ -2382,7 +2350,7 @@ note = uni0671.fina;
 },
 {
 glyphname = "highhamzaAlef-ar";
-lastChange = "2021-05-27 12:24:40 +0000";
+lastChange = "2022-07-06 15:38:46 +0000";
 layers = (
 {
 anchors = (
@@ -2397,17 +2365,16 @@ position = "{165, 756}";
 );
 components = (
 {
-alignment = -1;
-name = "alef_alt-hb.isol";
+alignment = 1;
+name = "highhamza-ar";
+transform = "{1, 0, 0, 1, 349, 0}";
 },
 {
-alignment = -1;
-name = "hamzaabove-ar";
-transform = "{1, 0, 0, 1, 404, -254}";
+name = "alef_alt-hb.isol";
 }
 );
 layerId = "307C4A58-79B8-4138-817C-FBEE21722E1A";
-width = 516;
+width = 875;
 },
 {
 anchors = (
@@ -2422,17 +2389,16 @@ position = "{145, 764}";
 );
 components = (
 {
-alignment = -1;
-name = "alef_alt-hb.isol";
+alignment = 1;
+name = "highhamza-ar";
+transform = "{1, 0, 0, 1, 289, 0}";
 },
 {
-alignment = -1;
-name = "hamzaabove-ar";
-transform = "{1, 0, 0, 1, 338, -254}";
+name = "alef_alt-hb.isol";
 }
 );
 layerId = "15908E2C-AB74-4DC1-B0E7-8741EE8F4DA5";
-width = 432;
+width = 779;
 },
 {
 anchors = (
@@ -2447,17 +2413,16 @@ position = "{125, 772}";
 );
 components = (
 {
-alignment = -1;
-name = "alef_alt-hb.isol";
+alignment = 1;
+name = "highhamza-ar";
+transform = "{1, 0, 0, 1, 220, 0}";
 },
 {
-alignment = -1;
-name = "hamzaabove-ar";
-transform = "{1, 0, 0, 1, 272, -214}";
+name = "alef_alt-hb.isol";
 }
 );
 layerId = "410295A1-92BC-4707-ABFC-13885E60878B";
-width = 348;
+width = 674;
 },
 {
 anchors = (
@@ -2472,17 +2437,16 @@ position = "{198, 781}";
 );
 components = (
 {
-alignment = -1;
-name = "alef_alt-hb.isol";
+alignment = 1;
+name = "highhamza-ar";
+transform = "{1, 0, 0, 1, 391, 0}";
 },
 {
-alignment = -1;
-name = "hamzaabove-ar";
-transform = "{1, 0, 0, 1, 448, -254}";
+name = "alef_alt-hb.isol";
 }
 );
 layerId = "DCD2D043-4E01-4B5D-9248-443A06E88532";
-width = 572;
+width = 941;
 }
 );
 note = uni0675;
@@ -80523,7 +80487,7 @@ width = 452;
 },
 {
 glyphname = "highhamzaWaw-ar";
-lastChange = "2019-10-23 10:25:22 +0000";
+lastChange = "2022-07-06 15:42:07 +0000";
 layers = (
 {
 anchors = (
@@ -80538,16 +80502,16 @@ position = "{444, 844}";
 );
 components = (
 {
-name = "waw-ar";
+alignment = 1;
+name = "highhamza-ar";
+transform = "{1, 0, 0, 1, 627, 0}";
 },
 {
-alignment = -1;
-name = "hamzaabove-ar";
-transform = "{1, 0, 0, 1, 480, -176}";
+name = "waw-ar";
 }
 );
 layerId = "307C4A58-79B8-4138-817C-FBEE21722E1A";
-width = 627;
+width = 1153;
 },
 {
 anchors = (
@@ -80562,16 +80526,16 @@ position = "{465, 821}";
 );
 components = (
 {
-name = "waw-ar";
+alignment = 1;
+name = "highhamza-ar";
+transform = "{1, 0, 0, 1, 561, 0}";
 },
 {
-alignment = -1;
-name = "hamzaabove-ar";
-transform = "{1, 0, 0, 1, 480, -176}";
+name = "waw-ar";
 }
 );
 layerId = "15908E2C-AB74-4DC1-B0E7-8741EE8F4DA5";
-width = 561;
+width = 1051;
 },
 {
 anchors = (
@@ -80586,16 +80550,15 @@ position = "{326, 798}";
 );
 components = (
 {
-name = "waw-ar";
+name = "highhamza-ar";
+transform = "{1, 0, 0, 1, 495, 0}";
 },
 {
-alignment = -1;
-name = "hamzaabove-ar";
-transform = "{1, 0, 0, 1, 410, -176}";
+name = "waw-ar";
 }
 );
 layerId = "410295A1-92BC-4707-ABFC-13885E60878B";
-width = 495;
+width = 949;
 },
 {
 anchors = (
@@ -80610,16 +80573,15 @@ position = "{516, 890}";
 );
 components = (
 {
-name = "waw-ar";
+name = "highhamza-ar";
+transform = "{1, 0, 0, 1, 681, 0}";
 },
 {
-alignment = -1;
-name = "hamzaabove-ar";
-transform = "{1, 0, 0, 1, 542, -176}";
+name = "waw-ar";
 }
 );
 layerId = "DCD2D043-4E01-4B5D-9248-443A06E88532";
-width = 681;
+width = 1231;
 }
 );
 note = uni0676;
@@ -80730,7 +80692,7 @@ note = uni0676.fina;
 },
 {
 glyphname = "uHamzaabove-ar";
-lastChange = "2019-10-23 10:25:18 +0000";
+lastChange = "2022-07-06 15:42:58 +0000";
 layers = (
 {
 anchors = (
@@ -80745,12 +80707,12 @@ position = "{314, 835}";
 );
 components = (
 {
-name = "waw-ar";
+alignment = 1;
+name = "highhamza-ar";
+transform = "{1, 0, 0, 1, 627, 0}";
 },
 {
-alignment = -1;
-name = "hamzaabove-ar";
-transform = "{1, 0, 0, 1, 480, -176}";
+name = "waw-ar";
 },
 {
 alignment = -1;
@@ -80759,7 +80721,7 @@ transform = "{1, 0, 0, 1, 141, -233}";
 }
 );
 layerId = "307C4A58-79B8-4138-817C-FBEE21722E1A";
-width = 627;
+width = 1153;
 },
 {
 anchors = (
@@ -80774,12 +80736,12 @@ position = "{332, 828}";
 );
 components = (
 {
-name = "waw-ar";
+alignment = 1;
+name = "highhamza-ar";
+transform = "{1, 0, 0, 1, 561, 0}";
 },
 {
-alignment = -1;
-name = "hamzaabove-ar";
-transform = "{1, 0, 0, 1, 480, -176}";
+name = "waw-ar";
 },
 {
 alignment = -1;
@@ -80788,7 +80750,7 @@ transform = "{1, 0, 0, 1, 141, -233}";
 }
 );
 layerId = "15908E2C-AB74-4DC1-B0E7-8741EE8F4DA5";
-width = 561;
+width = 1051;
 },
 {
 anchors = (
@@ -80803,12 +80765,12 @@ position = "{308, 821}";
 );
 components = (
 {
-name = "waw-ar";
+alignment = 1;
+name = "highhamza-ar";
+transform = "{1, 0, 0, 1, 495, 0}";
 },
 {
-alignment = -1;
-name = "hamzaabove-ar";
-transform = "{1, 0, 0, 1, 420, -176}";
+name = "waw-ar";
 },
 {
 alignment = -1;
@@ -80817,7 +80779,7 @@ transform = "{1, 0, 0, 1, 121, -233}";
 }
 );
 layerId = "410295A1-92BC-4707-ABFC-13885E60878B";
-width = 495;
+width = 949;
 },
 {
 anchors = (
@@ -80832,12 +80794,12 @@ position = "{362, 880}";
 );
 components = (
 {
-name = "waw-ar";
+alignment = 1;
+name = "highhamza-ar";
+transform = "{1, 0, 0, 1, 681, 0}";
 },
 {
-alignment = -1;
-name = "hamzaabove-ar";
-transform = "{1, 0, 0, 1, 510, -176}";
+name = "waw-ar";
 },
 {
 alignment = -1;
@@ -80846,7 +80808,7 @@ transform = "{1, 0, 0, 1, 171, -213}";
 }
 );
 layerId = "DCD2D043-4E01-4B5D-9248-443A06E88532";
-width = 681;
+width = 1231;
 }
 );
 note = uni0677;
@@ -80977,7 +80939,7 @@ note = uni0677.fina;
 },
 {
 glyphname = "highhamzaYeh-ar";
-lastChange = "2021-05-30 07:30:50 +0000";
+lastChange = "2022-07-06 15:44:05 +0000";
 layers = (
 {
 anchors = (
@@ -80992,15 +80954,16 @@ position = "{216, 584}";
 );
 components = (
 {
-name = "alefMaksura-ar";
+alignment = 1;
+name = "highhamza-ar";
+transform = "{1, 0, 0, 1, 883, 0}";
 },
 {
-name = "hamzaabove-ar";
-transform = "{1, 0, 0, 1, 225, -437}";
+name = "alefMaksura-ar";
 }
 );
 layerId = "307C4A58-79B8-4138-817C-FBEE21722E1A";
-width = 883;
+width = 1409;
 },
 {
 anchors = (
@@ -81015,15 +80978,16 @@ position = "{184, 553}";
 );
 components = (
 {
-name = "alefMaksura-ar";
+alignment = 1;
+name = "highhamza-ar";
+transform = "{1, 0, 0, 1, 839, 0}";
 },
 {
-name = "hamzaabove-ar";
-transform = "{1, 0, 0, 1, 225, -425}";
+name = "alefMaksura-ar";
 }
 );
 layerId = "15908E2C-AB74-4DC1-B0E7-8741EE8F4DA5";
-width = 839;
+width = 1329;
 },
 {
 anchors = (
@@ -81038,15 +81002,16 @@ position = "{182, 522}";
 );
 components = (
 {
-name = "alefMaksura-ar";
+alignment = 1;
+name = "highhamza-ar";
+transform = "{1, 0, 0, 1, 795, 0}";
 },
 {
-name = "hamzaabove-ar";
-transform = "{1, 0, 0, 1, 164, -450}";
+name = "alefMaksura-ar";
 }
 );
 layerId = "410295A1-92BC-4707-ABFC-13885E60878B";
-width = 795;
+width = 1249;
 },
 {
 anchors = (
@@ -81061,15 +81026,15 @@ position = "{237, 625}";
 );
 components = (
 {
-name = "alefMaksura-ar";
+name = "highhamza-ar";
+transform = "{1, 0, 0, 1, 912, 0}";
 },
 {
-name = "hamzaabove-ar";
-transform = "{1, 0, 0, 1, 225, -437}";
+name = "alefMaksura-ar";
 }
 );
 layerId = "DCD2D043-4E01-4B5D-9248-443A06E88532";
-width = 912;
+width = 1462;
 }
 );
 note = uni0678;

--- a/sources/NotoNaskhArabic.glyphs
+++ b/sources/NotoNaskhArabic.glyphs
@@ -1697,46 +1697,30 @@ unicode = "0621,FE80";
 glyphname = uni0674;
 layers = (
 {
-anchors = (
-{
-name = _top;
-position = "{66, 538}";
-},
-{
-name = top;
-position = "{57, 747}";
-}
-);
 components = (
 {
-name = uni0654;
-transform = "{1, 0, 0, 1, 6, 34}";
+alignment = -1;
+name = uni0621;
+transform = "{1, 0, 0, 1, 0, 230}";
 }
 );
 layerId = master01;
-width = 127;
+width = 437;
 },
 {
-anchors = (
-{
-name = _top;
-position = "{73, 565}";
-},
-{
-name = top;
-position = "{63, 793}";
-}
-);
 components = (
 {
-name = uni0654;
-transform = "{1, 0, 0, 1, 0, 117}";
+alignment = -1;
+name = uni0621;
+transform = "{1, 0, 0, 1, 0, 230}";
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
-width = 140;
+width = 452;
 }
 );
+leftMetricsKey = "=uni0621";
+rightMetricsKey = "=uni0621";
 unicode = 0674;
 },
 {
@@ -3427,59 +3411,55 @@ layers = (
 anchors = (
 {
 name = bottom;
-position = "{127, -100}";
+position = "{127, 35}";
 },
 {
 name = bottom.dot;
-position = "{127, -48}";
+position = "{127, 87}";
 },
 {
 name = top;
-position = "{123, 750}";
+position = "{123, 885}";
 }
 );
 components = (
 {
-alignment = -1;
-name = uni0627;
+name = uni0674;
+transform = "{1, 0, 0, 1, 238, 0}";
 },
 {
-alignment = -1;
-name = uni0654;
-transform = "{1, 0, 0, 1, 214, 34}";
+name = uni0627;
 }
 );
 layerId = master01;
-width = 337;
+width = 675;
 },
 {
 anchors = (
 {
 name = bottom;
-position = "{151, -110}";
+position = "{151, 25}";
 },
 {
 name = bottom.dot;
-position = "{151, -48}";
+position = "{151, 87}";
 },
 {
 name = top;
-position = "{146, 750}";
+position = "{146, 885}";
 }
 );
 components = (
 {
-alignment = -1;
-name = uni0627;
+name = uni0674;
+transform = "{1, 0, 0, 1, 284, 0}";
 },
 {
-alignment = -1;
-name = uni0654;
-transform = "{1, 0, 0, 1, 261, 43}";
+name = uni0627;
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
-width = 399;
+width = 736;
 }
 );
 unicode = 0675;
@@ -55903,59 +55883,55 @@ layers = (
 anchors = (
 {
 name = bottom;
-position = "{193, -252}";
+position = "{193, -117}";
 },
 {
 name = top;
-position = "{258, 580}";
+position = "{258, 715}";
 },
 {
 name = top.dot;
-position = "{256, 346}";
+position = "{256, 481}";
 }
 );
 components = (
 {
-alignment = -1;
-name = uni0648;
+name = uni0674;
+transform = "{1, 0, 0, 1, 468, 0}";
 },
 {
-alignment = -1;
-name = uni0654;
-transform = "{1, 0, 0, 1, 348, -127}";
+name = uni0648;
 }
 );
 layerId = master01;
-width = 468;
+width = 905;
 },
 {
 anchors = (
 {
 name = bottom;
-position = "{195, -245}";
+position = "{195, -110}";
 },
 {
 name = top;
-position = "{248, 620}";
+position = "{248, 755}";
 },
 {
 name = top.dot;
-position = "{269, 379}";
+position = "{269, 514}";
 }
 );
 components = (
 {
-alignment = -1;
-name = uni0648;
+name = uni0674;
+transform = "{1, 0, 0, 1, 497, 0}";
 },
 {
-alignment = -1;
-name = uni0654;
-transform = "{1, 0, 0, 1, 344, -101}";
+name = uni0648;
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
-width = 525;
+width = 949;
 }
 );
 unicode = 0676;
@@ -56047,21 +56023,20 @@ position = "{169, 563}";
 );
 components = (
 {
+name = uni0674;
+transform = "{1, 0, 0, 1, 468, 0}";
+},
+{
 name = uni0648;
 },
 {
 alignment = -1;
 name = uni064F;
 transform = "{1, 0, 0, 1, 111, -67}";
-},
-{
-alignment = -1;
-name = uni0654;
-transform = "{1, 0, 0, 1, 298, -127}";
 }
 );
 layerId = master01;
-width = 468;
+width = 905;
 },
 {
 anchors = (
@@ -56084,21 +56059,21 @@ position = "{185, 603}";
 );
 components = (
 {
+alignment = 1;
+name = uni0674;
+transform = "{1, 0, 0, 1, 497, 0}";
+},
+{
 name = uni0648;
 },
 {
 alignment = -1;
 name = uni064F;
 transform = "{1, 0, 0, 1, 127, -36}";
-},
-{
-alignment = -1;
-name = uni0654;
-transform = "{1, 0, 0, 1, 304, -98}";
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
-width = 497;
+width = 949;
 }
 );
 unicode = "0677,FBDD";
@@ -56208,17 +56183,16 @@ position = "{148, 74}";
 );
 components = (
 {
-alignment = -1;
-name = uni0649;
+alignment = 1;
+name = uni0674;
+transform = "{1.1, 0, 0, 1.1, 618, 0}";
 },
 {
-alignment = -1;
-name = uni0654;
-transform = "{1.1, 0, 0, 1.1, 577, -167}";
+name = uni0649;
 }
 );
 layerId = master01;
-width = 747;
+width = 1099;
 },
 {
 anchors = (
@@ -56241,17 +56215,16 @@ position = "{148, 104}";
 );
 components = (
 {
-alignment = -1;
-name = uni0649;
+alignment = 1;
+name = uni0674;
+transform = "{1.2, 0, 0, 1.2, 636, 0}";
 },
 {
-alignment = -1;
-name = uni0654;
-transform = "{1.2, 0, 0, 1.2, 579, -185}";
+name = uni0649;
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
-width = 771;
+width = 1178;
 }
 );
 unicode = 0678;
@@ -56432,17 +56405,15 @@ position = "{139, 387}";
 );
 components = (
 {
-alignment = -1;
-name = uni066E.init;
+name = uni0674;
+transform = "{1, 0, 0, 1, 275, 0}";
 },
 {
-alignment = -1;
-name = _519;
-transform = "{1, 0, 0, 1, 193, 30}";
+name = uni066E.init;
 }
 );
 layerId = master01;
-width = 352;
+width = 712;
 },
 {
 anchors = (
@@ -56465,17 +56436,15 @@ position = "{143, 423}";
 );
 components = (
 {
-alignment = -1;
-name = uni066E.init;
+name = uni0674;
+transform = "{1, 0, 0, 1, 275, 0}";
 },
 {
-alignment = -1;
-name = _519;
-transform = "{1, 0, 0, 1, 204, 195}";
+name = uni066E.init;
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
-width = 391;
+width = 727;
 }
 );
 },

--- a/sources/NotoNaskhArabicUI.glyphs
+++ b/sources/NotoNaskhArabicUI.glyphs
@@ -1714,46 +1714,30 @@ unicode = "0621,FE80";
 glyphname = uni0674;
 layers = (
 {
-anchors = (
-{
-name = _top;
-position = "{66, 673}";
-},
-{
-name = top;
-position = "{57, 882}";
-}
-);
 components = (
 {
-name = uni0654;
-transform = "{1, 0, 0, 1, 6, 34}";
+alignment = -1;
+name = uni0621;
+transform = "{1, 0, 0, 1, 0, 230}";
 }
 );
 layerId = master01;
-width = 127;
+width = 437;
 },
 {
-anchors = (
-{
-name = _top;
-position = "{73, 700}";
-},
-{
-name = top;
-position = "{63, 928}";
-}
-);
 components = (
 {
-name = uni0654;
-transform = "{1, 0, 0, 1, 0, 117}";
+alignment = -1;
+name = uni0621;
+transform = "{1, 0, 0, 1, 0, 230}";
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
-width = 140;
+width = 452;
 }
 );
+leftMetricsKey = "=uni0621";
+rightMetricsKey = "=uni0621";
 unicode = 0674;
 },
 {
@@ -3419,17 +3403,15 @@ position = "{123, 885}";
 );
 components = (
 {
-alignment = -1;
-name = uni0627;
+name = uni0674;
+transform = "{1, 0, 0, 1, 238, 0}";
 },
 {
-alignment = -1;
-name = uni0654;
-transform = "{1, 0, 0, 1, 214, 34}";
+name = uni0627;
 }
 );
 layerId = master01;
-width = 337;
+width = 675;
 },
 {
 anchors = (
@@ -3448,17 +3430,15 @@ position = "{146, 885}";
 );
 components = (
 {
-alignment = -1;
-name = uni0627;
+name = uni0674;
+transform = "{1, 0, 0, 1, 284, 0}";
 },
 {
-alignment = -1;
-name = uni0654;
-transform = "{1, 0, 0, 1, 261, 43}";
+name = uni0627;
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
-width = 399;
+width = 736;
 }
 );
 unicode = 0675;
@@ -55799,17 +55779,15 @@ position = "{256, 481}";
 );
 components = (
 {
-alignment = -1;
-name = uni0648;
+name = uni0674;
+transform = "{1, 0, 0, 1, 468, 0}";
 },
 {
-alignment = -1;
-name = uni0654;
-transform = "{1, 0, 0, 1, 348, -127}";
+name = uni0648;
 }
 );
 layerId = master01;
-width = 468;
+width = 905;
 },
 {
 anchors = (
@@ -55828,17 +55806,15 @@ position = "{269, 514}";
 );
 components = (
 {
-alignment = -1;
-name = uni0648;
+name = uni0674;
+transform = "{1, 0, 0, 1, 497, 0}";
 },
 {
-alignment = -1;
-name = uni0654;
-transform = "{1, 0, 0, 1, 344, -111}";
+name = uni0648;
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
-width = 525;
+width = 949;
 }
 );
 unicode = 0676;
@@ -55930,21 +55906,20 @@ position = "{169, 698}";
 );
 components = (
 {
+name = uni0674;
+transform = "{1, 0, 0, 1, 468, 0}";
+},
+{
 name = uni0648;
 },
 {
 alignment = -1;
 name = uni064F;
 transform = "{1, 0, 0, 1, 111, -67}";
-},
-{
-alignment = -1;
-name = uni0654;
-transform = "{1, 0, 0, 1, 298, -127}";
 }
 );
 layerId = master01;
-width = 468;
+width = 905;
 },
 {
 anchors = (
@@ -55967,21 +55942,21 @@ position = "{185, 738}";
 );
 components = (
 {
+alignment = 1;
+name = uni0674;
+transform = "{1, 0, 0, 1, 497, 0}";
+},
+{
 name = uni0648;
 },
 {
 alignment = -1;
 name = uni064F;
 transform = "{1, 0, 0, 1, 127, -36}";
-},
-{
-alignment = -1;
-name = uni0654;
-transform = "{1, 0, 0, 1, 304, -98}";
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
-width = 497;
+width = 949;
 }
 );
 unicode = "0677,FBDD";
@@ -56091,17 +56066,16 @@ position = "{148, 209}";
 );
 components = (
 {
-alignment = -1;
-name = uni0649;
+alignment = 1;
+name = uni0674;
+transform = "{1.1, 0, 0, 1.1, 618, 0}";
 },
 {
-alignment = -1;
-name = uni0654;
-transform = "{1.1, 0, 0, 1.1, 577, -167}";
+name = uni0649;
 }
 );
 layerId = master01;
-width = 747;
+width = 1099;
 },
 {
 anchors = (
@@ -56124,17 +56098,16 @@ position = "{148, 239}";
 );
 components = (
 {
-alignment = -1;
-name = uni0649;
+alignment = 1;
+name = uni0674;
+transform = "{1.2, 0, 0, 1.2, 636, 0}";
 },
 {
-alignment = -1;
-name = uni0654;
-transform = "{1.2, 0, 0, 1.2, 579, -215}";
+name = uni0649;
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
-width = 771;
+width = 1178;
 }
 );
 unicode = 0678;
@@ -56315,17 +56288,15 @@ position = "{139, 522}";
 );
 components = (
 {
-alignment = -1;
-name = uni066E.init;
+name = uni0674;
+transform = "{1, 0, 0, 1, 275, 0}";
 },
 {
-alignment = -1;
-name = _519;
-transform = "{1, 0, 0, 1, 193, 30}";
+name = uni066E.init;
 }
 );
 layerId = master01;
-width = 352;
+width = 712;
 },
 {
 anchors = (
@@ -56348,17 +56319,15 @@ position = "{143, 558}";
 );
 components = (
 {
-alignment = -1;
-name = uni066E.init;
+name = uni0674;
+transform = "{1, 0, 0, 1, 275, 0}";
 },
 {
-alignment = -1;
-name = _519;
-transform = "{1, 0, 0, 1, 204, 195}";
+name = uni066E.init;
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
-width = 391;
+width = 727;
 }
 );
 },


### PR DESCRIPTION
It is a spacing not a mark, its size should be that of ARABIC LETTER
HAMZA (U+0621) but raised above baseline. I made it a component of the
regular hamza, remove the erroneous mkmk anchors and raised it above
baseline.

I also fixed the deprecated characters that use it like ARABIC LETTER
HIGH HAMZAH WAW (U+0676), but only where it makes sense (i.e. isolated
and initial forms, since medial or final forms of these characters are
not attested).