### PR TITLE
Fixed dots in final and isol forms of U+06AD for Naskh and NaskhUI

### DIFF
--- a/sources/NotoNaskhArabic.glyphs
+++ b/sources/NotoNaskhArabic.glyphs
@@ -37255,7 +37255,7 @@ name = uni0643;
 },
 {
 name = uni06DB;
-transform = "{1, 0, 0, 1, 231, 154}";
+transform = "{1, 0, 0, 1, 231, -200}";
 }
 );
 layerId = master01;
@@ -37287,7 +37287,7 @@ name = uni0643;
 },
 {
 name = uni06DB;
-transform = "{1, 0, 0, 1, 264, 175}";
+transform = "{1, 0, 0, 1, 264, -150}";
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
@@ -37324,7 +37324,7 @@ name = uniFEDA;
 },
 {
 name = uni06DB;
-transform = "{1, 0, 0, 1, 359, 164}";
+transform = "{1, 0, 0, 1, 359, -200}";
 }
 );
 layerId = master01;
@@ -37355,7 +37355,7 @@ name = uniFEDA;
 },
 {
 name = uni06DB;
-transform = "{1, 0, 0, 1, 354, 185}";
+transform = "{1, 0, 0, 1, 353, -150}";
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";

--- a/sources/NotoNaskhArabicUI.glyphs
+++ b/sources/NotoNaskhArabicUI.glyphs
@@ -37238,7 +37238,7 @@ name = uni0643;
 },
 {
 name = uni06DB;
-transform = "{1, 0, 0, 1, 231, 154}";
+transform = "{1, 0, 0, 1, 231, -50}";
 }
 );
 layerId = master01;
@@ -37270,7 +37270,7 @@ name = uni0643;
 },
 {
 name = uni06DB;
-transform = "{1, 0, 0, 1, 264, 175}";
+transform = "{1, 0, 0, 1, 264, -30}";
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
@@ -37307,7 +37307,7 @@ name = uniFEDA;
 },
 {
 name = uni06DB;
-transform = "{1, 0, 0, 1, 359, 164}";
+transform = "{1, 0, 0, 1, 359, -50}";
 }
 );
 layerId = master01;
@@ -37338,7 +37338,7 @@ name = uniFEDA;
 },
 {
 name = uni06DB;
-transform = "{1, 0, 0, 1, 354, 185}";
+transform = "{1, 0, 0, 1, 354, -30}";
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";


### PR DESCRIPTION
fix #32
Two modified files
・ NotoNaskhArabic.glyphs
・ NotoNaskhArabicUI.glyphs

Two modified glyphs
・ U + 06AD final: "uniFBD4"
・ U + 06AD isol: "uni06AD"

All masters have been adjusted to be consistent.

The details of the work are as follows.
Lowered the dot positions of final and isol. No modifications have been made other than adjusting the position of the components.
The modified image is as follows

Before
![image](https://user-images.githubusercontent.com/21096794/181700482-e5a16acf-b467-4a77-9a20-b62fa7c82a41.png)

After
![image](https://user-images.githubusercontent.com/21096794/181700551-3cfcc7d9-4427-45a6-b58a-2f6d9576602a.png)
