### PR TITLE
Naskh: add _top3 anchor to alefabove

### DIFF
--- a/sources/NotoNaskhArabic.glyphs
+++ b/sources/NotoNaskhArabic.glyphs
@@ -97755,6 +97755,10 @@ name = _top.far;
 pos = (11,429);
 },
 {
+name = _top3;
+pos = (11,429);
+},
+{
 name = top.far;
 pos = (9,669);
 },
@@ -97793,6 +97797,10 @@ width = 0;
 anchors = (
 {
 name = _top.far;
+pos = (11,438);
+},
+{
+name = _top3;
 pos = (11,438);
 },
 {

--- a/sources/NotoNaskhArabicUI.glyphs
+++ b/sources/NotoNaskhArabicUI.glyphs
@@ -120291,6 +120291,10 @@ name = _top;
 position = "{11, 564}";
 },
 {
+name = _top3;
+position = "{11, 564}";
+},
+{
 name = top;
 position = "{9, 804}";
 }
@@ -120325,6 +120329,10 @@ width = 0;
 anchors = (
 {
 name = _top;
+position = "{11, 573}";
+},
+{
+name = _top3;
 position = "{11, 573}";
 },
 {


### PR DESCRIPTION
Currently "ٱللَّٰهِ" is broken.
Adding _top3 anchor to U+0670 to fix it.

Before:
<img width="74" alt="Screenshot 2023-05-02 at 13 33 33" src="https://user-images.githubusercontent.com/1923747/235654803-6f88c1db-ca3f-460c-8033-7aedad655038.png">

After:
<img width="97" alt="Screenshot 2023-05-02 at 13 33 50" src="https://user-images.githubusercontent.com/1923747/235654861-f2f25408-9ab2-415a-a0e1-bac317449199.png">
