### PR TITLE
Fix U+FEE9 shape

### DIFF
--- a/sources/GlyphData.xml
+++ b/sources/GlyphData.xml
@@ -675,7 +675,6 @@
   <glyph
       name="heh-ar"
       unicode="0647"
-      unicode2="FEE9"
       production="uni0647"
       script="arabic"
       category="Letter"
@@ -766,6 +765,7 @@
   <glyph
       name="ae-ar"
       unicode="06D5"
+      unicode2="FEE9"
       production="uni06D5"
       script="arabic"
       category="Letter"

--- a/sources/NotoKufiArabic.glyphspackage/glyphs/ae-ar.glyph
+++ b/sources/NotoKufiArabic.glyphspackage/glyphs/ae-ar.glyph
@@ -243,5 +243,5 @@ width = 654;
 }
 );
 note = uni06D5;
-unicode = 06D5;
+unicode = "06D5,FEE9";
 }

--- a/sources/NotoKufiArabic.glyphspackage/glyphs/heh-ar.glyph
+++ b/sources/NotoKufiArabic.glyphspackage/glyphs/heh-ar.glyph
@@ -295,5 +295,5 @@ width = 1001;
 }
 );
 note = uni06BE;
-unicode = "0647,FEE9";
+unicode = 0647;
 }

--- a/sources/NotoNaskhArabic.glyphspackage/glyphs/ae-ar.glyph
+++ b/sources/NotoNaskhArabic.glyphspackage/glyphs/ae-ar.glyph
@@ -158,5 +158,5 @@ nodes = (
 width = 425;
 }
 );
-unicode = 1749;
+unicode = (1749,65257);
 }

--- a/sources/NotoNaskhArabic.glyphspackage/glyphs/heh-ar.glyph
+++ b/sources/NotoNaskhArabic.glyphspackage/glyphs/heh-ar.glyph
@@ -65,5 +65,5 @@ width = 670;
 }
 );
 metricRight = "=heh-ar";
-unicode = (1607,65257);
+unicode = 1607;
 }

--- a/sources/NotoSansArabic.glyphspackage/glyphs/ae-ar.glyph
+++ b/sources/NotoSansArabic.glyphspackage/glyphs/ae-ar.glyph
@@ -434,5 +434,5 @@ nodes = (
 width = 544;
 }
 );
-unicode = 06D5;
+unicode = "06D5,FEE9";
 }

--- a/sources/NotoSansArabic.glyphspackage/glyphs/heh-ar.glyph
+++ b/sources/NotoSansArabic.glyphspackage/glyphs/heh-ar.glyph
@@ -155,5 +155,5 @@ width = 799;
 }
 );
 rightMetricsKey = "heh-ar.init";
-unicode = "0647,FEE9";
+unicode = 0647;
 }


### PR DESCRIPTION
The heh-ar glyph was double encoded as U+0647 and U+FEE9, but it now has a shape similar to hehDoachashmee-ar which is meant for but not U+FEE9.

Move U+FEE9 Unicode assignment to ae-ar instead.

Fixes https://github.com/notofonts/arabic/issues/206