### PR TITLE
Add anchor to space and thinspace glyphs

### DIFF
--- a/sources/NotoKufiArabic.glyphspackage/glyphs/space.glyph
+++ b/sources/NotoKufiArabic.glyphspackage/glyphs/space.glyph
@@ -4,6 +4,10 @@ layers = (
 {
 anchors = (
 {
+name = bottom;
+position = "{170, -78}";
+},
+{
 name = stop;
 position = "{170, 424}";
 },
@@ -21,6 +25,10 @@ width = 340;
 },
 {
 anchors = (
+{
+name = bottom;
+position = "{170, -78}";
+},
 {
 name = stop;
 position = "{170, 424}";
@@ -40,6 +48,10 @@ width = 340;
 {
 anchors = (
 {
+name = bottom;
+position = "{170, -78}";
+},
+{
 name = stop;
 position = "{170, 424}";
 },
@@ -57,6 +69,10 @@ width = 340;
 },
 {
 anchors = (
+{
+name = bottom;
+position = "{170, -78}";
+},
 {
 name = stop;
 position = "{170, 424}";

--- a/sources/NotoKufiArabic.glyphspackage/glyphs/thinspace.glyph
+++ b/sources/NotoKufiArabic.glyphspackage/glyphs/thinspace.glyph
@@ -4,6 +4,10 @@ layers = (
 {
 anchors = (
 {
+name = bottom;
+position = "{85, -78}";
+},
+{
 name = stop;
 position = "{85, 424}";
 },
@@ -21,6 +25,10 @@ width = 170;
 },
 {
 anchors = (
+{
+name = bottom;
+position = "{85, -78}";
+},
 {
 name = stop;
 position = "{85, 424}";
@@ -40,6 +48,10 @@ width = 170;
 {
 anchors = (
 {
+name = bottom;
+position = "{85, -78}";
+},
+{
 name = stop;
 position = "{85, 424}";
 },
@@ -57,6 +69,10 @@ width = 170;
 },
 {
 anchors = (
+{
+name = bottom;
+position = "{85, -78}";
+},
 {
 name = stop;
 position = "{85, 424}";

--- a/sources/NotoNaskhArabic.glyphspackage/glyphs/space.glyph
+++ b/sources/NotoNaskhArabic.glyphspackage/glyphs/space.glyph
@@ -4,6 +4,10 @@ layers = (
 {
 anchors = (
 {
+name = bottom;
+pos = (111,-94);
+},
+{
 name = stop;
 pos = (111,424);
 },
@@ -21,6 +25,10 @@ width = 221;
 },
 {
 anchors = (
+{
+name = bottom;
+pos = (111,-94);
+},
 {
 name = stop;
 pos = (111,424);

--- a/sources/NotoNaskhArabic.glyphspackage/glyphs/thinspace.glyph
+++ b/sources/NotoNaskhArabic.glyphspackage/glyphs/thinspace.glyph
@@ -4,6 +4,10 @@ layers = (
 {
 anchors = (
 {
+name = bottom;
+pos = (56,-94);
+},
+{
 name = stop;
 pos = (56,424);
 },
@@ -21,6 +25,10 @@ width = 111;
 },
 {
 anchors = (
+{
+name = bottom;
+pos = (56,-94);
+},
 {
 name = stop;
 pos = (56,424);

--- a/sources/NotoSansArabic.glyphspackage/glyphs/space.glyph
+++ b/sources/NotoSansArabic.glyphspackage/glyphs/space.glyph
@@ -4,7 +4,15 @@ layers = (
 {
 anchors = (
 {
+name = bottom;
+position = "{130, -100}";
+},
+{
 name = stop;
+position = "{130, 400}";
+},
+{
+name = top;
 position = "{130, 400}";
 }
 );
@@ -14,7 +22,15 @@ width = 260;
 {
 anchors = (
 {
+name = bottom;
+position = "{130, -100}";
+},
+{
 name = stop;
+position = "{130, 400}";
+},
+{
+name = top;
 position = "{130, 400}";
 }
 );
@@ -24,7 +40,15 @@ width = 260;
 {
 anchors = (
 {
+name = bottom;
+position = "{130, -100}";
+},
+{
 name = stop;
+position = "{130, 400}";
+},
+{
+name = top;
 position = "{130, 400}";
 }
 );
@@ -34,7 +58,15 @@ width = 260;
 {
 anchors = (
 {
+name = bottom;
+position = "{130, -100}";
+},
+{
 name = stop;
+position = "{130, 400}";
+},
+{
+name = top;
 position = "{130, 400}";
 }
 );
@@ -44,7 +76,15 @@ width = 260;
 {
 anchors = (
 {
+name = bottom;
+position = "{130, -100}";
+},
+{
 name = stop;
+position = "{130, 400}";
+},
+{
+name = top;
 position = "{130, 400}";
 }
 );
@@ -59,7 +99,15 @@ width = 260;
 {
 anchors = (
 {
+name = bottom;
+position = "{130, -100}";
+},
+{
 name = stop;
+position = "{130, 400}";
+},
+{
+name = top;
 position = "{130, 400}";
 }
 );
@@ -69,7 +117,15 @@ width = 260;
 {
 anchors = (
 {
+name = bottom;
+position = "{130, -100}";
+},
+{
 name = stop;
+position = "{130, 400}";
+},
+{
+name = top;
 position = "{130, 400}";
 }
 );
@@ -79,7 +135,15 @@ width = 260;
 {
 anchors = (
 {
+name = bottom;
+position = "{130, -100}";
+},
+{
 name = stop;
+position = "{130, 400}";
+},
+{
+name = top;
 position = "{130, 400}";
 }
 );

--- a/sources/NotoSansArabic.glyphspackage/glyphs/thinspace.glyph
+++ b/sources/NotoSansArabic.glyphspackage/glyphs/thinspace.glyph
@@ -4,7 +4,15 @@ layers = (
 {
 anchors = (
 {
+name = bottom;
+position = "{65, -100}";
+},
+{
 name = stop;
+position = "{65, 400}";
+},
+{
+name = top;
 position = "{65, 400}";
 }
 );
@@ -14,7 +22,15 @@ width = 130;
 {
 anchors = (
 {
+name = bottom;
+position = "{65, -100}";
+},
+{
 name = stop;
+position = "{65, 400}";
+},
+{
+name = top;
 position = "{65, 400}";
 }
 );
@@ -24,7 +40,15 @@ width = 130;
 {
 anchors = (
 {
+name = bottom;
+position = "{65, -100}";
+},
+{
 name = stop;
+position = "{65, 400}";
+},
+{
+name = top;
 position = "{65, 400}";
 }
 );
@@ -34,7 +58,15 @@ width = 130;
 {
 anchors = (
 {
+name = bottom;
+position = "{65, -100}";
+},
+{
 name = stop;
+position = "{65, 400}";
+},
+{
+name = top;
 position = "{65, 400}";
 }
 );
@@ -44,7 +76,15 @@ width = 130;
 {
 anchors = (
 {
+name = bottom;
+position = "{65, -100}";
+},
+{
 name = stop;
+position = "{65, 400}";
+},
+{
+name = top;
 position = "{65, 400}";
 }
 );
@@ -54,7 +94,15 @@ width = 130;
 {
 anchors = (
 {
+name = bottom;
+position = "{65, -100}";
+},
+{
 name = stop;
+position = "{65, 400}";
+},
+{
+name = top;
 position = "{65, 400}";
 }
 );
@@ -64,7 +112,15 @@ width = 130;
 {
 anchors = (
 {
+name = bottom;
+position = "{65, -100}";
+},
+{
 name = stop;
+position = "{65, 400}";
+},
+{
+name = top;
 position = "{65, 400}";
 }
 );
@@ -74,7 +130,15 @@ width = 130;
 {
 anchors = (
 {
+name = bottom;
+position = "{65, -100}";
+},
+{
 name = stop;
+position = "{65, 400}";
+},
+{
+name = top;
 position = "{65, 400}";
 }
 );


### PR DESCRIPTION
They are often used as bases for standalone marks, and it seems without anchors Chrome will badly position the marks on them (I think it might be splitting the text at the space glyph and partially shaping it).

For example, the word فَٱدَّ ٰرَءٖۡتُمۡ has the small alef above mispositioned in Chrome with Noto Sans Arabic.

FontBakery also complains that we are not attaching marks to the space, and this change should fix it as well.