### PR TITLE
[naskh] Fix allah-ar ligature

### DIFF
--- a/sources/NotoNaskhArabic.glyphspackage/fontinfo.plist
+++ b/sources/NotoNaskhArabic.glyphspackage/fontinfo.plist
@@ -990,10 +990,11 @@ tag = rlig;
 },
 {
 code = "lookup allah {
-lookupflag UseMarkFilteringSet [shadda-ar alefabove-ar];
-  sub alef-ar lam-ar.init lam-ar.medi shadda-ar alefabove-ar heh-ar.fina by allah-ar;
-  sub alef-ar lam-ar.init lam-ar.medi shadda-ar alefabove-ar hehgoal-ar.fina by allah-ar;
-} allah;";
+lookupflag UseMarkFilteringSet [shadda_alefabove-ar];
+  sub alef-ar lam-ar.init lam-ar.medi shadda_alefabove-ar heh-ar.fina by allah-ar;
+  sub alef-ar lam-ar.init lam-ar.medi shadda_alefabove-ar hehgoal-ar.fina by allah-ar;
+} allah;
+";
 tag = liga;
 },
 {


### PR DESCRIPTION
The shadda and small alef get ligated before it, so the context needs to reflect that.

Fixes https://github.com/notofonts/arabic/issues/227