### PR TITLE
Fixes Kurdish lam-alef ligature in Noto Sans Arabic UI fonts

### DIFF
--- a/sources/config-sans-arabic-ui.yaml
+++ b/sources/config-sans-arabic-ui.yaml
@@ -1,4 +1,4 @@
-buildVariable: true
+buildVariable: false
 familyName: Noto Sans Arabic UI
 googleFonts: true
 includeSubsets:


### PR DESCRIPTION
Hi team - the OpenStreetMap project uses Noto fonts on most map tiles. For some time they've had an issue with about 1,000 place names in the Kurdish region which use **ڵا** , a ~three~ two-character ligature (original Noto issue: https://github.com/notofonts/arabic/issues/8 )

This got fixed in Noto Arabic, but not in the **UI** fonts, which I heard were deprecated.
Admin was concerned that changing to the current Noto Arabic fonts would have larger effects such as line-height.
Last year I reviewed the fix to ligatures in the main Noto Sans font (added anchors, rewritten ligature rules), and applied them to the UI font. You can see my font here: https://mapmeld.com/arabic/index.html

I've put the changes into this PR.  One issue which I couldn't resolve, is I had to turn off variable fonts on the UI font for the bolder and lighter fonts to build the new anchors correctly.  I am new to the fonts world, so if you can flag what might be causing this issue, I'm happy to go back and review.

Sample error when variable fonts is on:
```
ERROR:fontmake.compatibility:
Fonts had differing anchors in glyph alefTwoabove-ar.fina:
 * Noto Sans Arabic UI Light, Noto Sans Arabic UI Regular, Noto Sans Arabic UI Condensed had:
    "bottom, top, top.digit"
 * Noto Sans Arabic UI SemiBold, Noto Sans Arabic UI Bold, Noto Sans Arabic UI Condensed Light, Noto Sans Arabic UI Condensed SemiBold, Noto Sans Arabic UI Condensed Bold had: "bottom, top"
```